### PR TITLE
Don't clean the packages from the apt cache...

### DIFF
--- a/ubuntu-1204/Dockerfile
+++ b/ubuntu-1204/Dockerfile
@@ -28,6 +28,9 @@ RUN mkdir -p /home/vagrant/.ssh \
     && chmod 0600 /home/vagrant/.ssh/authorized_keys \
     && chown -R vagrant /home/vagrant/.ssh
 
+# don't clean packages, we might be using vagrant-cachier
+RUN rm /etc/apt/apt.conf.d/docker-clean
+
 # run sshd in the foreground
 CMD /usr/sbin/sshd -D \
     -o UseDNS=no\

--- a/ubuntu-1404/Dockerfile
+++ b/ubuntu-1404/Dockerfile
@@ -28,6 +28,9 @@ RUN mkdir -p /home/vagrant/.ssh \
     && chmod 0600 /home/vagrant/.ssh/authorized_keys \
     && chown -R vagrant /home/vagrant/.ssh
 
+# don't clean packages, we might be using vagrant-cachier
+RUN rm /etc/apt/apt.conf.d/docker-clean
+
 # run sshd in the foreground
 CMD /usr/sbin/sshd -D \
     -o UseDNS=no\


### PR DESCRIPTION
...otherwise we can't use the base images with vagrant-cachier.
(it would wipe out the apt cache after every package that is installed)
