### PR TITLE
Adding Python to Ubuntu 16.04 Docker Image and fixing locales bug

### DIFF
--- a/ubuntu-1604/Dockerfile
+++ b/ubuntu-1604/Dockerfile
@@ -4,15 +4,17 @@ MAINTAINER Torben Knerr <mail@tknerr.de>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# ensure we have the en_US.UTF-8 locale available
-RUN locale-gen en_US.UTF-8
-
 # install common dependencies
 RUN apt-get update && apt-get install -y \
+    locales \
     curl \
     lsb-release \
     openssh-server \
-    sudo
+    sudo \
+    python
+
+# ensure we have the en_US.UTF-8 locale available
+RUN locale-gen en_US.UTF-8
 
 # setup the vagrant user
 RUN if ! getent passwd vagrant; then useradd -d /home/vagrant -m -s /bin/bash vagrant; fi \


### PR DESCRIPTION
This pull request would fix the locales bug #8 and add Python to the Ubuntu 16.04 Docker Image so it can be used by Ansible.