### PR TITLE
Fix CircleCI build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'vagrant-wrapper', '2.0.2'
 gem 'rspec', '3.2.0'
 gem 'mixlib-shellout', '2.0.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'rspec', '3.2.0'
 gem 'mixlib-shellout', '2.0.1'
+gem 'rake'

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ On top of the official distro base image it includes:
 
 The intended use of the Vagrant-friendly docker base images is to use them as a basebox in your `Vagrantfile`. These baseboxes simply reference one of the [actual docker base images](https://github.com/tknerr/vagrant-docker-baseimages#docker-base-images) below.
 
-The following baseboxes are currently published on [Atlas](https://atlas.hashicorp.com/boxes/search):
+The following baseboxes are currently published on [Atlas](https://app.vagrantup.com/boxes/search):
 
- * [`tknerr/baseimage-ubuntu-12.04`](https://atlas.hashicorp.com/tknerr/boxes/baseimage-ubuntu-12.04)
- * [`tknerr/baseimage-ubuntu-14.04`](https://atlas.hashicorp.com/tknerr/boxes/baseimage-ubuntu-14.04)
- * [`tknerr/baseimage-ubuntu-16.04`](https://atlas.hashicorp.com/tknerr/boxes/baseimage-ubuntu-16.04)
+ * [`tknerr/baseimage-ubuntu-12.04`](https://app.vagrantup.com/tknerr/boxes/baseimage-ubuntu-12.04)
+ * [`tknerr/baseimage-ubuntu-14.04`](https://app.vagrantup.com/tknerr/boxes/baseimage-ubuntu-14.04)
+ * [`tknerr/baseimage-ubuntu-16.04`](https://app.vagrantup.com/tknerr/boxes/baseimage-ubuntu-16.04)
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -60,28 +60,6 @@ Bringing machine 'default' up with 'docker' provider...
 ==> default: Machine booted and ready!
 ```
 
-### Warning - it might not work as expected (Vagrant =< 1.7.2)
-
-> **Please note**: until version 1.7.2 of Vagrant the docker provisioner [does not inspect
-> the packaged Vagrantfile](https://github.com/mitchellh/vagrant/issues/5667)
-> in the basebox, i.e. it might fail with an error like that:
-> ```
-> $ vagrant up --provider docker
-> Bringing machine 'default' up with 'docker' provider...
-> There are errors in the configuration of this machine. Please fix
-> the following errors and try again:
->
-> docker provider:
-> * One of "build_dir" or "image" must be set
-> ```
-> As a workaround you have to import the desired basebox once, so it is available
-> locally and the docker provider can inspect the Vagrantfile [we package into the box](https://github.com/tknerr/vagrant-docker-baseimages/blob/ea692a56b5b004135f7db08c2720418ad8bfc9a4/spec/helpers.rb#L34-38):
-> ```
-> $ vagrant box add tknerr/baseimage-ubuntu-16.04
-> ```
-> After that, you can use the `config.vm.box` with the docker baseimage as expected.
-
-
 ## Docker Base Images
 
 In case you want to work with the actual docker base images directly, the following ones (see subdirectories) are available on [docker hub](https://registry.hub.docker.com):

--- a/circle.yml
+++ b/circle.yml
@@ -11,8 +11,8 @@ dependencies:
     - ~/.vagrant.d
     - ~/docker
   pre:
-    - wget https://releases.hashicorp.com/vagrant/1.7.2/vagrant_1.7.2_x86_64.deb
-    - sudo dpkg -i vagrant_1.7.2_x86_64.deb
+    - wget https://releases.hashicorp.com/vagrant/2.1.2/vagrant_2.1.2_x86_64.deb
+    - sudo dpkg -i vagrant_2.1.2_x86_64.deb
   override:
     # cache the docker images / layers
     - if [[ -e ~/docker/ubuntu-images.tar ]]; then docker load -i ~/docker/ubuntu-images.tar; fi

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
     version: 2.1.5
   environment:
     VAGRANT_DEFAULT_PROVIDER: docker
+    DEBUG_COMMANDS: true
 
 dependencies:
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     version: 2.1.5
   environment:
     VAGRANT_DEFAULT_PROVIDER: docker
-    DEBUG_COMMANDS: true
+    #DEBUG_COMMANDS: true
 
 dependencies:
   cache_directories:

--- a/spec/basebox_spec.rb
+++ b/spec/basebox_spec.rb
@@ -15,8 +15,7 @@ describe 'base boxes for the docker baseimages' do
 
         # need to import the basebox once, see mitchellh/vagrant#5667
         basebox = "tknerr/baseimage-#{platform}-#{version}"
-        cmd = Mixlib::ShellOut.new("vagrant box add #{basebox}")
-        result = cmd.run_command
+        result = run_command("vagrant box add #{basebox}")
         expect(result.stdout).to include "==> box: Successfully added box '#{basebox}' (v1.0.0) for 'docker'!"
         expect(result.status.exitstatus).to eq 0
       end
@@ -26,16 +25,14 @@ describe 'base boxes for the docker baseimages' do
       end
 
       describe "tknerr/baseimage-#{platform}-#{version}" do
-        it 'comes up on  `vagrant up --provider docker`' do
-          cmd = Mixlib::ShellOut.new("vagrant up --provider docker", :cwd => @tempdir)
-          result = cmd.run_command
+        it 'comes up on `vagrant up --provider docker`' do
+          result = run_command("vagrant up --provider docker", :cwd => @tempdir)
           expect(result.stdout).to include "==> default: Machine booted and ready!"
           expect(result.stderr).to match ""
           expect(result.status.exitstatus).to eq 0
         end
         it 'can be destroyed via `vagrant destroy`' do
-          cmd = Mixlib::ShellOut.new("vagrant destroy -f", :cwd => @tempdir)
-          result = cmd.run_command
+          result = run_command("vagrant destroy -f", :cwd => @tempdir)
           expect(result.stdout).to include "==> default: Deleting the container..."
           # destroying containers does not work on circleci
           unless ENV['CIRCLECI']

--- a/spec/basebox_spec.rb
+++ b/spec/basebox_spec.rb
@@ -15,7 +15,7 @@ describe 'base boxes for the docker baseimages' do
 
         # need to import the basebox once, see mitchellh/vagrant#5667
         basebox = "tknerr/baseimage-#{platform}-#{version}"
-        result = run_command("vagrant box add #{basebox}")
+        result = run_command("vagrant box add --force #{basebox}")
         expect(result.stdout).to include "==> box: Successfully added box '#{basebox}' (v1.0.0) for 'docker'!"
         expect(result.status.exitstatus).to eq 0
       end

--- a/spec/baseimage_spec.rb
+++ b/spec/baseimage_spec.rb
@@ -46,7 +46,7 @@ describe 'vagrant-friendly docker baseimages' do
         it 'can be provisioned with a shell script via `vagrant provision`' do
           result = run_command("vagrant provision", :cwd => @tempdir)
           expect(result.stdout).to include "==> default: Running provisioner: shell..."
-          expect(result.stdout).to include "==> default: hello docker!"
+          expect(result.stdout).to include "    default: hello docker!"
           expect(result.stderr).to match ""
           expect(result.status.exitstatus).to eq 0
         end

--- a/spec/baseimage_spec.rb
+++ b/spec/baseimage_spec.rb
@@ -20,51 +20,44 @@ describe 'vagrant-friendly docker baseimages' do
 
       describe "#{platform}-#{version}" do
         it 'is not created when I run `vagrant status`' do
-          cmd = Mixlib::ShellOut.new("vagrant status", :cwd => @tempdir)
-          result = cmd.run_command
+          result = run_command("vagrant status", :cwd => @tempdir)
           expect(result.stdout).to include "not created (docker)"
           expect(result.stderr).to match ""
           expect(result.status.exitstatus).to eq 0
         end
         it 'comes up when I run `vagrant up --no-provision`' do
-          cmd = Mixlib::ShellOut.new("vagrant up --no-provision", :cwd => @tempdir)
-          result = cmd.run_command
+          result = run_command("vagrant up --no-provision", :cwd => @tempdir)
           expect(result.stdout).to include "==> default: Machine booted and ready!"
           expect(result.stderr).to match ""
           expect(result.status.exitstatus).to eq 0
         end
         it 'is now shown as running when I run `vagrant status` again' do
-          cmd = Mixlib::ShellOut.new("vagrant status", :cwd => @tempdir)
-          result = cmd.run_command
+          result = run_command("vagrant status", :cwd => @tempdir)
           expect(result.stdout).to include "running (docker)"
           expect(result.stderr).to match ""
           expect(result.status.exitstatus).to eq 0
         end
         it 'accepts remote ssh commands via `vagrant ssh -c`' do
-          cmd = Mixlib::ShellOut.new("vagrant ssh -c pwd", :cwd => @tempdir)
-          result = cmd.run_command
+          result = run_command("vagrant ssh -c pwd", :cwd => @tempdir)
           expect(result.stdout).to include "/home/vagrant"
           expect(result.stderr).to match ""
           expect(result.status.exitstatus).to eq 0
         end
         it 'can be provisioned with a shell script via `vagrant provision`' do
-          cmd = Mixlib::ShellOut.new("vagrant provision", :cwd => @tempdir)
-          result = cmd.run_command
+          result = run_command("vagrant provision", :cwd => @tempdir)
           expect(result.stdout).to include "==> default: Running provisioner: shell..."
           expect(result.stdout).to include "==> default: hello docker!"
           expect(result.stderr).to match ""
           expect(result.status.exitstatus).to eq 0
         end
         it 'can be stopped via `vagrant halt`' do
-          cmd = Mixlib::ShellOut.new("vagrant halt", :cwd => @tempdir)
-          result = cmd.run_command
+          result = run_command("vagrant halt", :cwd => @tempdir)
           expect(result.stdout).to include "==> default: Stopping container..."
           expect(result.stderr).to match ""
           expect(result.status.exitstatus).to eq 0
         end
         it 'can be destroyed via `vagrant destroy`' do
-          cmd = Mixlib::ShellOut.new("vagrant destroy -f", :cwd => @tempdir)
-          result = cmd.run_command
+          result = run_command("vagrant destroy -f", :cwd => @tempdir)
           expect(result.stdout).to include "==> default: Deleting the container..."
           # destroying containers does not work on circleci
           unless ENV['CIRCLECI']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ def run_command(cmd, **opts)
     puts "stdout:\n#{result.stdout}"
     puts "========================================"
     puts "stderr:\n#{result.stderr}"
+    puts "========================================"
   end
   result
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,3 +3,17 @@ require 'mixlib/shellout'
 require 'helpers'
 
 include Helpers
+
+def run_command(cmd, **opts)
+  shellout = Mixlib::ShellOut.new(cmd, opts)
+  result = shellout.run_command
+  if ENV['DEBUG_COMMANDS']
+    puts "========================================"
+    puts "ran command '#{cmd}' with opts '#{opts}'"
+    puts "========================================"
+    puts "stdout:\n#{result.stdout}"
+    puts "========================================"
+    puts "stderr:\n#{result.stderr}"
+  end
+  result
+end


### PR DESCRIPTION
CI build was broken due to usage of the outdated vagrant 1.7.2 version, which still tries to resolve the baseboxes from the old atlas URLs.

This PR:

 * fixes the CI build by updating to latest Vagrant 2.1.2
 * removes the unnecessary / outdated vagrant-wrapper gem from the bundle
 * adds better debugging facilities via the `DEBUG_COMMANDS` env var
 * fixes the failing tests after updating to Vagrant 2.1.2