### PR TITLE
Fix: Ubuntu 20.04 ships with python3, so don't install python2

### DIFF
--- a/ubuntu-2004/Dockerfile
+++ b/ubuntu-2004/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     lsb-release \
     openssh-server \
     sudo \
-    python
+    python3
 
 # ensure we have the en_US.UTF-8 locale available
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
As the title says... I will re-push the updated `baseimage-ubuntu:20.04` image to dockerhub right after this PR is merged