### PR TITLE
Add Ubuntu 22.04 base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The intended use of the Vagrant-friendly docker base images is to use them as a 
 
 The following baseboxes are currently published on [Vagrant Cloud](https://app.vagrantup.com/boxes/search):
 
+ * [`tknerr/baseimage-ubuntu-22.04`](https://app.vagrantup.com/tknerr/boxes/baseimage-ubuntu-22.04)
  * [`tknerr/baseimage-ubuntu-20.04`](https://app.vagrantup.com/tknerr/boxes/baseimage-ubuntu-20.04)
  * [`tknerr/baseimage-ubuntu-18.04`](https://app.vagrantup.com/tknerr/boxes/baseimage-ubuntu-18.04)
  * [`tknerr/baseimage-ubuntu-16.04`](https://app.vagrantup.com/tknerr/boxes/baseimage-ubuntu-16.04)
@@ -28,10 +29,10 @@ The following baseboxes are currently published on [Vagrant Cloud](https://app.v
 
 Use the `config.vm.box` setting to specify the basebox in your Vagrantfile.
 
-For example, run `vagrant init tknerr/baseimage-ubuntu-20.04 --minimal` to create the Vagrantfile below:
+For example, run `vagrant init tknerr/baseimage-ubuntu-22.04 --minimal` to create the Vagrantfile below:
 ```ruby
 Vagrant.configure(2) do |config|
-  config.vm.box = "tknerr/baseimage-ubuntu-20.04"
+  config.vm.box = "tknerr/baseimage-ubuntu-22.04"
 end
 ```
 
@@ -41,7 +42,7 @@ W:\repo\sample>vagrant up --provider=docker
 Bringing machine 'default' up with 'docker' provider...
 ==> default: Creating the container...
     default:   Name: minimal_default_1441605508
-    default:  Image: tknerr/baseimage-ubuntu:20.04
+    default:  Image: tknerr/baseimage-ubuntu:22.04
     default: Volume: /w/repo/sample:/vagrant
     default:   Port: 0.0.0.0:2222:22
     default:
@@ -65,6 +66,7 @@ Bringing machine 'default' up with 'docker' provider...
 
 In case you want to work with the actual docker base images directly, the following ones (see subdirectories) are available on [docker hub](https://registry.hub.docker.com):
 
+ * [`tknerr/baseimage-ubuntu:22.04`](https://hub.docker.com/r/tknerr/baseimage-ubuntu/tags/)
  * [`tknerr/baseimage-ubuntu:20.04`](https://hub.docker.com/r/tknerr/baseimage-ubuntu/tags/)
  * [`tknerr/baseimage-ubuntu:18.04`](https://hub.docker.com/r/tknerr/baseimage-ubuntu/tags/)
  * [`tknerr/baseimage-ubuntu:16.04`](https://hub.docker.com/r/tknerr/baseimage-ubuntu/tags/)
@@ -77,7 +79,7 @@ run `vagrant up`:
 ```ruby
 Vagrant.configure(2) do |config|
   config.vm.provider "docker" do |d|
-    d.image = "tknerr/baseimage-ubuntu:20.04"
+    d.image = "tknerr/baseimage-ubuntu:22.04"
   end
 end
 ```
@@ -87,7 +89,7 @@ this container has ssh enabled:
 ```ruby
 Vagrant.configure(2) do |config|
   config.vm.provider "docker" do |d|
-    d.image = "tknerr/baseimage-ubuntu:20.04"
+    d.image = "tknerr/baseimage-ubuntu:22.04"
     d.has_ssh = true
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@
 require 'rubygems/package'
 
 PLATFORMS = {
-  ubuntu: ["14.04", "16.04", "18.04", "20.04"]
+  ubuntu: ["14.04", "16.04", "18.04", "20.04", "22.04"]
 }
 
 desc "build the docker base images"

--- a/spec/basebox_spec.rb
+++ b/spec/basebox_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'base boxes for the docker baseimages' do
 
   PLATFORMS = {
-    ubuntu: ["14.04", "16.04", "18.04", "20.04"]
+    ubuntu: ["14.04", "16.04", "18.04", "20.04", "22.04"]
   }
 
   before(:all) do

--- a/spec/baseimage_spec.rb
+++ b/spec/baseimage_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'vagrant-friendly docker baseimages' do
 
   PLATFORMS = {
-    ubuntu: ["14.04", "16.04", "18.04", "20.04"]
+    ubuntu: ["14.04", "16.04", "18.04", "20.04", "22.04"]
   }
 
   before(:all) do

--- a/ubuntu-1404/Dockerfile
+++ b/ubuntu-1404/Dockerfile
@@ -26,8 +26,8 @@ RUN if ! getent passwd vagrant; then useradd -d /home/vagrant -m -s /bin/bash va
 RUN mkdir -p /home/vagrant/.ssh \
     && chmod 0700 /home/vagrant/.ssh \
     && wget --no-check-certificate \
-      https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub \
-      -O /home/vagrant/.ssh/authorized_keys \
+    https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub \
+    -O /home/vagrant/.ssh/authorized_keys \
     && chmod 0600 /home/vagrant/.ssh/authorized_keys \
     && chown -R vagrant /home/vagrant/.ssh
 

--- a/ubuntu-1604/Dockerfile
+++ b/ubuntu-1604/Dockerfile
@@ -28,8 +28,8 @@ RUN if ! getent passwd vagrant; then useradd -d /home/vagrant -m -s /bin/bash va
 RUN mkdir -p /home/vagrant/.ssh \
     && chmod 0700 /home/vagrant/.ssh \
     && wget --no-check-certificate \
-      https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub \
-      -O /home/vagrant/.ssh/authorized_keys \
+    https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub \
+    -O /home/vagrant/.ssh/authorized_keys \
     && chmod 0600 /home/vagrant/.ssh/authorized_keys \
     && chown -R vagrant /home/vagrant/.ssh
 

--- a/ubuntu-1804/Dockerfile
+++ b/ubuntu-1804/Dockerfile
@@ -28,8 +28,8 @@ RUN if ! getent passwd vagrant; then useradd -d /home/vagrant -m -s /bin/bash va
 RUN mkdir -p /home/vagrant/.ssh \
     && chmod 0700 /home/vagrant/.ssh \
     && wget --no-check-certificate \
-      https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub \
-      -O /home/vagrant/.ssh/authorized_keys \
+    https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub \
+    -O /home/vagrant/.ssh/authorized_keys \
     && chmod 0600 /home/vagrant/.ssh/authorized_keys \
     && chown -R vagrant /home/vagrant/.ssh
 

--- a/ubuntu-2004/Dockerfile
+++ b/ubuntu-2004/Dockerfile
@@ -28,8 +28,8 @@ RUN if ! getent passwd vagrant; then useradd -d /home/vagrant -m -s /bin/bash va
 RUN mkdir -p /home/vagrant/.ssh \
     && chmod 0700 /home/vagrant/.ssh \
     && wget --no-check-certificate \
-      https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub \
-      -O /home/vagrant/.ssh/authorized_keys \
+    https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub \
+    -O /home/vagrant/.ssh/authorized_keys \
     && chmod 0600 /home/vagrant/.ssh/authorized_keys \
     && chown -R vagrant /home/vagrant/.ssh
 

--- a/ubuntu-2204/Dockerfile
+++ b/ubuntu-2204/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# install common dependencies
+RUN apt-get update && apt-get install -y \
+    locales \
+    curl \
+    lsb-release \
+    openssh-server \
+    sudo \
+    python3
+
+# ensure we have the en_US.UTF-8 locale available
+RUN locale-gen en_US.UTF-8
+
+# setup the vagrant user
+RUN if ! getent passwd vagrant; then useradd -d /home/vagrant -m -s /bin/bash vagrant; fi \
+    && echo vagrant:vagrant | chpasswd \
+    && echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && mkdir -p /etc/sudoers.d \
+    && echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/vagrant \
+    && chmod 0440 /etc/sudoers.d/vagrant
+
+# add the vagrant insecure public key
+RUN mkdir -p /home/vagrant/.ssh \
+    && chmod 0700 /home/vagrant/.ssh \
+    && wget --no-check-certificate \
+    https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub \
+    -O /home/vagrant/.ssh/authorized_keys \
+    && chmod 0600 /home/vagrant/.ssh/authorized_keys \
+    && chown -R vagrant /home/vagrant/.ssh
+
+# don't clean packages, we might be using vagrant-cachier
+RUN rm /etc/apt/apt.conf.d/docker-clean
+
+# create the privilege separation directory for sshd
+RUN mkdir -p /run/sshd
+
+# run sshd in the foreground
+CMD /usr/sbin/sshd -D \
+    -o UseDNS=no\
+    -o UsePAM=no\
+    -o PasswordAuthentication=yes\
+    -o PidFile=/tmp/sshd.pid


### PR DESCRIPTION
Hello Torben

I added a base image for Ubuntu 22.04 so it can be used as Vagrant base box. It is an almost identical copy of the Ubuntu 20.04, as all of the instructions are still necessary and working with 22.04.

I also noticed that the URL where the Vagrant public SSH key is located changed. Using the old URL still worked, however it printed a warning when the curl request was redirected. I changed that in all the Dockerfiles.