### PR TITLE
Improve Developer Experience (updated README, new Rake tasks, etc)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,17 +21,17 @@ jobs:
       # build
       - run:
           name: Build Docker Base Images
-          command: bundle exec rake build:docker:base_images
+          command: bundle exec rake build:docker:base_images PLATFORM=all
       - run:
           name: Build Vagrant Baseboxes
-          command: bundle exec rake build:vagrant:baseboxes
+          command: bundle exec rake build:vagrant:baseboxes PLATFORM=all
       # test
       - run:
           name: Integration Test for Docker Base Images
-          command: bundle exec rake test:docker:base_images
+          command: bundle exec rake test:docker:base_images PLATFORM=all
       - run:
           name: Integration Test for Vagrant Baseboxes
-          command: bundle exec rake test:vagrant:baseboxes
+          command: bundle exec rake test:vagrant:baseboxes PLATFORM=all
       # publish
       - store_test_results:
           path: out/test-results

--- a/README.md
+++ b/README.md
@@ -98,8 +98,85 @@ Vagrant.configure(2) do |config|
 end
 ```
 
+## Development
 
-## Contribute
+### Prerequisites
+
+Prerequisites you need to have installed:
+
+* Docker
+* Vagrant
+* Ruby
+
+### Building and Testing
+
+Install bundler dependencies first:
+```
+$ bundle install
+```
+
+To build the Docker Base Images for Ubuntu 22.04:
+```
+$ bundle exec rake build:docker:base_images PLATFORM=ubuntu-22.04
+```
+
+Run integration tests for the Docker Base Image:
+```
+$ bundle exec rake test:docker:base_images PLATFORM=ubuntu-22.04
+rspec --format doc --color --tty spec/baseimage_spec.rb
+
+vagrant-friendly docker baseimages
+  ubuntu-22.04
+    is referenced in a `Vagrantfile` as a docker image
+    is not created when I run `vagrant status`
+    comes up when I run `vagrant up --no-provision`
+    is now shown as running when I run `vagrant status` again
+    accepts remote ssh commands via `vagrant ssh -c`
+    can be provisioned with a shell script via `vagrant provision`
+    is DISTRIB_ID=Ubuntu / DISTRIB_RELEASE=22.04 in lsb-release file
+    can be stopped via `vagrant halt`
+    can be destroyed via `vagrant destroy`
+
+Finished in 46.74 seconds (files took 0.31354 seconds to load)
+9 examples, 0 failuress
+```
+
+In order to build the Vagrant Basebox "wrappers" around it:
+```
+$ bundle exec rake build:vagrant:baseboxes PLATFORM=ubuntu-22.04
+```
+
+Run integration tests for the Vagrant Basebox:
+```
+$ bundle exec rake test:vagrant:baseboxes PLATFORM=ubuntu-22.04
+rspec --format doc --color --tty spec/basebox_spec.rb
+
+base boxes for the docker baseimages
+  tknerr/baseimage-ubuntu-22.04
+    is referenced in a `Vagrantfile` as a basebox
+    can be imported via `vagrant box add`
+    comes up via `vagrant up --provider docker`
+    can be destroyed via `vagrant destroy`
+
+Finished in 30.08 seconds (files took 0.61239 seconds to load)
+4 examples, 0 failures
+```
+
+### Publishing
+
+This is currently done manually, and requires to log in to dockerhub / vagrantcloud interactively.
+
+To publish the docker base image for Ubuntu 22.04 to dockerhub:
+```
+$ bundle exec rake publish:docker:base_images PLATFORM=ubuntu-22.04
+```
+
+To publish the corresponding vagrant basebox to vagrantcloud:
+```
+$ bundle exec rake publish:vagrant:baseboxes PLATFORM=ubuntu-22.04
+```
+
+## Contributing
 
 How to contribute?
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,47 +1,67 @@
 
 require 'rubygems/package'
 
-PLATFORMS = {
-  ubuntu: ["14.04", "16.04", "18.04", "20.04", "22.04"]
+ALL_PLATFORMS = {
+  ubuntu: [ "14.04", "16.04", "18.04", "20.04", "22.04"]
 }
+
+def selected_platforms
+  platform = ENV.fetch('PLATFORM', 'ubuntu-22.04').strip
+  if platform == 'all'
+    ALL_PLATFORMS
+  else
+    os, version = platform.split('-')
+    {
+      os.to_sym => version.nil? ? ALL_PLATFORMS[os.to_sym] : [ version ]
+    }
+  end
+end
 
 desc "build the docker base images"
 task "build:docker:base_images" do
-  PLATFORMS.each_pair do |platform, versions|
+  selected_platforms.each_pair do |os, versions|
     versions.each do |version|
-      build_docker_image(platform, version)
+      build_docker_image(os, version)
     end
   end
 end
 
 desc "test the docker base images"
 task "test:docker:base_images" do
-  run_rspec("baseimage_spec")
+  selected_platforms.each_pair do |os, versions|
+    versions.each do |version|
+      run_rspec("baseimage_spec", os, version)
+    end
+  end
 end
 
 desc "build the vagrant baseboxes"
 task "build:vagrant:baseboxes" do
-  PLATFORMS.each_pair do |platform, versions|
+  selected_platforms.each_pair do |os, versions|
     versions.each do |version|
-      build_vagrant_basebox(platform, version)
+      build_vagrant_basebox(os, version)
     end
   end
 end
 
 desc "test the vagrant baseboxes"
 task "test:vagrant:baseboxes" do
-  run_rspec("basebox_spec")
+  selected_platforms.each_pair do |os, versions|
+    versions.each do |version|
+      run_rspec("basebox_spec", os, version)
+    end
+  end
 end
 
 
-def build_docker_image(platform, version)
-  image = "tknerr/baseimage-#{platform}:#{version}"
+def build_docker_image(os, version)
+  image = "tknerr/baseimage-#{os}:#{version}"
   sh "docker rmi #{image} -f"
-  sh "docker build --no-cache -t #{image} #{dir(platform, version)}"
+  sh "docker build --no-cache -t #{image} #{dir(os, version)}"
 end
 
-def build_vagrant_basebox(platform, version)
-  box = File.open("#{dir(platform, version)}/baseimage-#{platform}-#{version}.box","wb")
+def build_vagrant_basebox(os, version)
+  box = File.open("#{dir(os, version)}/baseimage-#{os}-#{version}.box","wb")
   Gem::Package::TarWriter.new(box) do |tar|
     tar.add_file("metadata.json", 0644) do |f|
       f.write <<~METADATA
@@ -54,7 +74,7 @@ def build_vagrant_basebox(platform, version)
       f.write <<~VAGRANTFILE
         Vagrant.configure(2) do |config|
           config.vm.provider "docker" do |d|
-            d.image = "tknerr/baseimage-#{platform}:#{version}"
+            d.image = "tknerr/baseimage-#{os}:#{version}"
             d.has_ssh = true
           end
         end
@@ -63,13 +83,15 @@ def build_vagrant_basebox(platform, version)
   end
 end
 
-def run_rspec(spec_name)
+def run_rspec(spec_name, os, version)
+  ENV['OS_UNDER_TEST'] = os.to_s
+  ENV['VERSION_UNDER_TEST'] = version.to_s
   sh "rspec --format doc --color --tty \
-            --format RspecJunitFormatter --out out/test-results/junit/#{spec_name}-junit-report.xml \
-            --format html --out out/test-results/#{spec_name}-test-report.html \
+            --format RspecJunitFormatter --out out/test-results/junit/#{spec_name}-#{os}-#{version}-junit-report.xml \
+            --format html --out out/test-results/#{spec_name}-#{os}-#{version}-test-report.html \
             spec/#{spec_name}.rb"
 end
 
-def dir(platform, version)
-  "#{platform}-#{version.delete('.')}"
+def dir(os, version)
+  "#{os}-#{version.delete('.')}"
 end

--- a/spec/basebox_spec.rb
+++ b/spec/basebox_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 describe 'base boxes for the docker baseimages' do
 
-  PLATFORMS = {
-    ubuntu: ["14.04", "16.04", "18.04", "20.04", "22.04"]
-  }
-
   before(:all) do
     @tempdir = Dir.mktmpdir
   end
@@ -14,37 +10,32 @@ describe 'base boxes for the docker baseimages' do
     FileUtils.rm_rf @tempdir
   end
 
-  PLATFORMS.each_pair do |platform, versions|
-    versions.each do |version|
-
-      describe "tknerr/baseimage-#{platform}-#{version}" do
-        it 'is referenced in a `Vagrantfile` as a basebox' do
-          write_config(@tempdir, vagrantfile_referencing_local_basebox(platform, version))
-          expect(File.read("#{@tempdir}/Vagrantfile")).to include <<~SNIPPET
-            config.vm.box = "tknerr/baseimage-#{platform}-#{version}"
-          SNIPPET
-        end
-        it 'can be imported via `vagrant box add`' do
-          basebox_name = "tknerr/baseimage-#{platform}-#{version}"
-          basebox_file = "#{platform}-#{version.delete('.')}/baseimage-#{platform}-#{version}.box"
-          result = run_command("vagrant box add --name #{basebox_name} --provider docker --force #{basebox_file}")
-          expect(result.stdout).to include "==> box: Box file was not detected as metadata. Adding it directly..."
-          expect(result.stdout).to include "==> box: Successfully added box '#{basebox_name}' (v0) for 'docker'!"
-          expect(result.status.exitstatus).to eq 0
-        end
-        it 'comes up via `vagrant up --provider docker`' do
-          result = run_command("vagrant up --provider docker", :cwd => @tempdir)
-          expect(result.stdout).to include "==> default: Machine booted and ready!"
-          expect(result.stderr).to match ""
-          expect(result.status.exitstatus).to eq 0
-        end
-        it 'can be destroyed via `vagrant destroy`' do
-          result = run_command("vagrant destroy -f", :cwd => @tempdir)
-          expect(result.stdout).to include "==> default: Deleting the container..."
-          expect(result.stderr).to match ""
-          expect(result.status.exitstatus).to eq 0
-        end
-      end
+  describe "tknerr/baseimage-#{os}-#{version}" do
+    it 'is referenced in a `Vagrantfile` as a basebox' do
+      write_config(@tempdir, vagrantfile_referencing_local_basebox(os, version))
+      expect(File.read("#{@tempdir}/Vagrantfile")).to include <<~SNIPPET
+        config.vm.box = "tknerr/baseimage-#{os}-#{version}"
+      SNIPPET
+    end
+    it 'can be imported via `vagrant box add`' do
+      basebox_name = "tknerr/baseimage-#{os}-#{version}"
+      basebox_file = "#{os}-#{version.delete('.')}/baseimage-#{os}-#{version}.box"
+      result = run_command("vagrant box add --name #{basebox_name} --provider docker --force #{basebox_file}")
+      expect(result.stdout).to include "==> box: Box file was not detected as metadata. Adding it directly..."
+      expect(result.stdout).to include "==> box: Successfully added box '#{basebox_name}' (v0) for 'docker'!"
+      expect(result.status.exitstatus).to eq 0
+    end
+    it 'comes up via `vagrant up --provider docker`' do
+      result = run_command("vagrant up --provider docker", :cwd => @tempdir)
+      expect(result.stdout).to include "==> default: Machine booted and ready!"
+      expect(result.stderr).to match ""
+      expect(result.status.exitstatus).to eq 0
+    end
+    it 'can be destroyed via `vagrant destroy`' do
+      result = run_command("vagrant destroy -f", :cwd => @tempdir)
+      expect(result.stdout).to include "==> default: Deleting the container..."
+      expect(result.stderr).to match ""
+      expect(result.status.exitstatus).to eq 0
     end
   end
 end

--- a/spec/baseimage_spec.rb
+++ b/spec/baseimage_spec.rb
@@ -50,6 +50,13 @@ describe 'vagrant-friendly docker baseimages' do
       expect(result.stderr).to match ""
       expect(result.status.exitstatus).to eq 0
     end
+    it "is DISTRIB_ID=#{os.capitalize} / DISTRIB_RELEASE=#{version} in lsb-release file" do
+      result = run_command("vagrant ssh -c 'cat /etc/lsb-release'", :cwd => @tempdir)
+      expect(result.stdout).to include "DISTRIB_ID=#{os.capitalize}"
+      expect(result.stdout).to include "DISTRIB_RELEASE=#{version}"
+      expect(result.stderr).to match ""
+      expect(result.status.exitstatus).to eq 0
+    end
     it 'can be stopped via `vagrant halt`' do
       result = run_command("vagrant halt", :cwd => @tempdir)
       expect(result.stdout).to include "==> default: Stopping container..."

--- a/spec/baseimage_spec.rb
+++ b/spec/baseimage_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 describe 'vagrant-friendly docker baseimages' do
 
-  PLATFORMS = {
-    ubuntu: ["14.04", "16.04", "18.04", "20.04", "22.04"]
-  }
-
   before(:all) do
     @tempdir = Dir.mktmpdir
     ENV['VAGRANT_DEFAULT_PROVIDER'] = 'docker'
@@ -15,61 +11,56 @@ describe 'vagrant-friendly docker baseimages' do
     FileUtils.rm_rf @tempdir
   end
 
-  PLATFORMS.each_pair do |platform, versions|
-    versions.each do |version|
-
-      describe "#{platform}-#{version}" do
-        it 'is referenced in a `Vagrantfile` as a docker image' do
-          write_config(@tempdir, vagrantfile_referencing_docker_baseimage(platform, version))
-          expect(File.read("#{@tempdir}/Vagrantfile")).to include <<~SNIPPET
-            d.image = "tknerr/baseimage-#{platform}:#{version}"
-          SNIPPET
-        end
-        it 'is not created when I run `vagrant status`' do
-          result = run_command("vagrant status", :cwd => @tempdir)
-          expect(result.stdout).to include "not created (docker)"
-          expect(result.stderr).to match ""
-          expect(result.status.exitstatus).to eq 0
-        end
-        it 'comes up when I run `vagrant up --no-provision`' do
-          result = run_command("vagrant up --no-provision", :cwd => @tempdir)
-          expect(result.stdout).to include "Image: tknerr/baseimage-#{platform}:#{version}"
-          expect(result.stdout).to include "==> default: Machine booted and ready!"
-          expect(result.stderr).to match ""
-          expect(result.status.exitstatus).to eq 0
-        end
-        it 'is now shown as running when I run `vagrant status` again' do
-          result = run_command("vagrant status", :cwd => @tempdir)
-          expect(result.stdout).to include "running (docker)"
-          expect(result.stderr).to match ""
-          expect(result.status.exitstatus).to eq 0
-        end
-        it 'accepts remote ssh commands via `vagrant ssh -c`' do
-          result = run_command("vagrant ssh -c pwd", :cwd => @tempdir)
-          expect(result.stdout).to include "/home/vagrant"
-          expect(result.stderr).to match ""
-          expect(result.status.exitstatus).to eq 0
-        end
-        it 'can be provisioned with a shell script via `vagrant provision`' do
-          result = run_command("vagrant provision", :cwd => @tempdir)
-          expect(result.stdout).to include "==> default: Running provisioner: shell..."
-          expect(result.stdout).to include "    default: hello docker!"
-          expect(result.stderr).to match ""
-          expect(result.status.exitstatus).to eq 0
-        end
-        it 'can be stopped via `vagrant halt`' do
-          result = run_command("vagrant halt", :cwd => @tempdir)
-          expect(result.stdout).to include "==> default: Stopping container..."
-          expect(result.stderr).to match ""
-          expect(result.status.exitstatus).to eq 0
-        end
-        it 'can be destroyed via `vagrant destroy`' do
-          result = run_command("vagrant destroy -f", :cwd => @tempdir)
-          expect(result.stdout).to include "==> default: Deleting the container..."
-          expect(result.stderr).to match ""
-          expect(result.status.exitstatus).to eq 0
-        end
-      end
+  describe "#{os}-#{version}" do
+    it 'is referenced in a `Vagrantfile` as a docker image' do
+      write_config(@tempdir, vagrantfile_referencing_docker_baseimage(os, version))
+      expect(File.read("#{@tempdir}/Vagrantfile")).to include <<~SNIPPET
+        d.image = "tknerr/baseimage-#{os}:#{version}"
+      SNIPPET
+    end
+    it 'is not created when I run `vagrant status`' do
+      result = run_command("vagrant status", :cwd => @tempdir)
+      expect(result.stdout).to include "not created (docker)"
+      expect(result.stderr).to match ""
+      expect(result.status.exitstatus).to eq 0
+    end
+    it 'comes up when I run `vagrant up --no-provision`' do
+      result = run_command("vagrant up --no-provision", :cwd => @tempdir)
+      expect(result.stdout).to include "Image: tknerr/baseimage-#{os}:#{version}"
+      expect(result.stdout).to include "==> default: Machine booted and ready!"
+      expect(result.stderr).to match ""
+      expect(result.status.exitstatus).to eq 0
+    end
+    it 'is now shown as running when I run `vagrant status` again' do
+      result = run_command("vagrant status", :cwd => @tempdir)
+      expect(result.stdout).to include "running (docker)"
+      expect(result.stderr).to match ""
+      expect(result.status.exitstatus).to eq 0
+    end
+    it 'accepts remote ssh commands via `vagrant ssh -c`' do
+      result = run_command("vagrant ssh -c pwd", :cwd => @tempdir)
+      expect(result.stdout).to include "/home/vagrant"
+      expect(result.stderr).to match ""
+      expect(result.status.exitstatus).to eq 0
+    end
+    it 'can be provisioned with a shell script via `vagrant provision`' do
+      result = run_command("vagrant provision", :cwd => @tempdir)
+      expect(result.stdout).to include "==> default: Running provisioner: shell..."
+      expect(result.stdout).to include "    default: hello docker!"
+      expect(result.stderr).to match ""
+      expect(result.status.exitstatus).to eq 0
+    end
+    it 'can be stopped via `vagrant halt`' do
+      result = run_command("vagrant halt", :cwd => @tempdir)
+      expect(result.stdout).to include "==> default: Stopping container..."
+      expect(result.stderr).to match ""
+      expect(result.status.exitstatus).to eq 0
+    end
+    it 'can be destroyed via `vagrant destroy`' do
+      result = run_command("vagrant destroy -f", :cwd => @tempdir)
+      expect(result.stdout).to include "==> default: Deleting the container..."
+      expect(result.stderr).to match ""
+      expect(result.status.exitstatus).to eq 0
     end
   end
 end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,13 +1,4 @@
 
-
-# reopen String class to add #unindent for heredocs
-# see http://stackoverflow.com/a/3772911/2388971
-class String
-  def unindent
-    gsub(/^#{scan(/^\s*/).min_by{|l|l.length}}/, "")
-  end
-end
-
 # helper methods
 module Helpers
 

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -15,11 +15,19 @@ module Helpers
     File.write "#{dir}/Vagrantfile", content
   end
 
-  def vagrantfile_referencing_docker_baseimage(platform, version)
+  def os
+    ENV.fetch('OS_UNDER_TEST')
+  end
+
+  def version
+    ENV.fetch('VERSION_UNDER_TEST')
+  end
+
+  def vagrantfile_referencing_docker_baseimage(os, version)
     <<~VAGRANTFILE
       Vagrant.configure(2) do |config|
         config.vm.provider "docker" do |d|
-          d.image = "tknerr/baseimage-#{platform}:#{version}"
+          d.image = "tknerr/baseimage-#{os}:#{version}"
           d.has_ssh = true
         end
 
@@ -29,10 +37,10 @@ module Helpers
     VAGRANTFILE
   end
 
-  def vagrantfile_referencing_local_basebox(platform, version)
+  def vagrantfile_referencing_local_basebox(os, version)
     <<~VAGRANTFILE
       Vagrant.configure(2) do |config|
-        config.vm.box = "tknerr/baseimage-#{platform}-#{version}"
+        config.vm.box = "tknerr/baseimage-#{os}-#{version}"
         config.vm.box_version = "0"
       end
     VAGRANTFILE


### PR DESCRIPTION
Improves the developer experience:

* refactor Rake tasks and tests so that you can now build selected platforms only, e.g.
    * `rake <task> PLATFORM=all` will build all os / version combinations
    * `rake <task> PLATFORM=ubuntu` will build all `ubuntu` versions
    * `rake <task> PLATFORM=ubuntu-22.04` will build only the `ubuntu` `22.04` version
* added new (interactive) rake tasks for publishing to dockerhub and vagrantcloud:
    * `rake publish:docker:base_images` will publish the selected Docker base images to dockerhub
    * `rake publish:vagrant:baseboxes` will publish the selected Vagrant baseboxes to vagrantcloud
* added missing development section to README, describing the usage of the rake tasks for development