### PR TITLE
Install bundled gems to vendor/bundle directory

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 vendor/
 out/
 *.box
-Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .vagrant/
-.bundle/
 vendor/
 out/
 *.box

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,33 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.5.0)
+    mixlib-shellout (2.0.1)
+    rake (13.1.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.1)
+    rspec_junit_formatter (0.5.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mixlib-shellout (= 2.0.1)
+  rake
+  rspec (= 3.11.0)
+  rspec_junit_formatter (= 0.5.1)
+
+BUNDLED WITH
+   2.3.9

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Prerequisites you need to have installed:
 
 Install bundler dependencies first:
 ```
-$ bundle install --path vendor/bundle
+$ bundle install
 ```
 
 To build the Docker Base Images for Ubuntu 22.04:

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Prerequisites you need to have installed:
 
 Install bundler dependencies first:
 ```
-$ bundle install
+$ bundle install --path vendor/bundle
 ```
 
 To build the Docker Base Images for Ubuntu 22.04:


### PR DESCRIPTION
Installing bundled gems system wide is discouraged, so we install it to the `vendor/bundle` directory. We also add the `Gemfile.lock` to version control so we get reproducible builds