### PR TITLE
Add multi-arch support (amd64 + arm64)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ jobs:
       - run:
           name: Install Vagrant
           command: |
-            wget https://releases.hashicorp.com/vagrant/2.2.19/vagrant_2.2.19_x86_64.deb
-            sudo dpkg -i vagrant_2.2.19_x86_64.deb
+            wget https://releases.hashicorp.com/vagrant/2.4.0/vagrant_2.4.0-1_amd64.deb
+            sudo dpkg -i vagrant_2.4.0-1_amd64.deb
       - run:
           name: Install Ruby Gems
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,11 @@ jobs:
           name: Install Ruby Gems
           command: |
             bundle check || bundle install --jobs=4 --retry=3
+      - run:
+          name: Install QEMU
+          command: |
+            sudo apt update
+            sudo apt install qemu-user-static -y
       # build
       - run:
           name: Build Docker Base Images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,13 @@
-version: 2
+version: 2.1
+
 jobs:
   build:
+    parameters:
+      platform:
+        type: string
     machine:
       image: ubuntu-2004:current
+    resource_class: medium
     environment:
       VAGRANT_DEFAULT_PROVIDER: docker
     steps:
@@ -25,19 +30,32 @@ jobs:
       # build
       - run:
           name: Build Docker Base Images
-          command: bundle exec rake build:docker:base_images PLATFORM=all
+          command: bundle exec rake build:docker:base_images PLATFORM=<< parameters.platform >>
       - run:
           name: Build Vagrant Baseboxes
-          command: bundle exec rake build:vagrant:baseboxes PLATFORM=all
+          command: bundle exec rake build:vagrant:baseboxes PLATFORM=<< parameters.platform >>
       # test
       - run:
           name: Integration Test for Docker Base Images
-          command: bundle exec rake test:docker:base_images PLATFORM=all
+          command: bundle exec rake test:docker:base_images PLATFORM=<< parameters.platform >>
       - run:
           name: Integration Test for Vagrant Baseboxes
-          command: bundle exec rake test:vagrant:baseboxes PLATFORM=all
+          command: bundle exec rake test:vagrant:baseboxes PLATFORM=<< parameters.platform >>
       # publish
       - store_test_results:
           path: out/test-results
       - store_artifacts:
           path: out/test-results
+
+workflows:
+  all-builds:
+    jobs:
+      - build:
+          matrix:
+            parameters:
+              platform:
+                - ubuntu-14.04
+                - ubuntu-16.04
+                - ubuntu-18.04
+                - ubuntu-20.04
+                - ubuntu-22.04

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ jobs:
       - run:
           name: Install Ruby Gems
           command: |
-            bundle config set --local path 'vendor/bundle'
             bundle check || bundle install --jobs=4 --retry=3
       # build
       - run:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![Circle CI](https://circleci.com/gh/tknerr/vagrant-docker-baseimages/tree/master.svg?style=shield)](https://circleci.com/gh/tknerr/vagrant-docker-baseimages/tree/master)
 
-A collection of Vagrant-friendly docker base images + corresponding Vagrant baseboxes. Something inbetween the
-official distro base image and [puhsion/baseimage](https://phusion.github.io/baseimage-docker/),
-just enough to make it work with Vagrant.
+A collection of Vagrant-friendly docker base images (published for `linux/amd64` and `linux/arm64` platforms) along with corresponding Vagrant baseboxes. Something inbetween the
+official distro base image and [puhsion/baseimage](https://phusion.github.io/baseimage-docker/), just enough to make it work with Vagrant.
 
 On top of the official distro base image it includes:
 
@@ -62,9 +61,27 @@ Bringing machine 'default' up with 'docker' provider...
 ==> default: Machine booted and ready!
 ```
 
+### Multi-Platform Support
+
+In case you want bring up the docker base images for an architecture different from your host OS
+you can do that by setting the `$DOCKER_DEFAULT_PLATFORM` environment variable.
+
+For example, to run the arm64 base image on an amd64 host:
+```
+$ DOCKER_DEFAULT_PLATFORM=linux/arm64 vagrant up --povider docker
+```
+
+Or vice versa, to use the amd64 base image:
+```
+$ DOCKER_DEFAULT_PLATFORM=linux/amd64 vagrant up --povider docker
+```
+
+**Please note:** running the base image under an architecture different from your host OS will run the container emulated under QEMU,
+which might be substantially slower than running the container under the native architecture!
+
 ## Docker Base Images
 
-In case you want to work with the actual docker base images directly, the following ones (see subdirectories) are available on [docker hub](https://registry.hub.docker.com):
+In case you want to work with the actual docker base images directly, the following ones (see subdirectories) are available on [docker hub](https://registry.hub.docker.com) (published as multi-arch docker images, supporting `linux/amd64` and `linux/arm64` platforms):
 
  * [`tknerr/baseimage-ubuntu:22.04`](https://hub.docker.com/r/tknerr/baseimage-ubuntu/tags/)
  * [`tknerr/baseimage-ubuntu:20.04`](https://hub.docker.com/r/tknerr/baseimage-ubuntu/tags/)
@@ -98,6 +115,19 @@ Vagrant.configure(2) do |config|
 end
 ```
 
+### Multi-Platform Support
+
+As an alternative to using the `$DOCKER_DEFAULT_PLATFORM` environment variable mentioned above, you can also
+pass the desired `--platform` directly via the docker provider configuration in your Vagrantfile:
+```ruby
+Vagrant.configure(2) do |config|
+  config.vm.provider "docker" do |d|
+    d.image = "tknerr/baseimage-ubuntu:22.04"
+    d.create_args = [ '--platform=linux/arm64' ]
+  end
+end
+```
+
 ## Development
 
 ### Prerequisites
@@ -126,7 +156,8 @@ $ bundle exec rake test:docker:base_images PLATFORM=ubuntu-22.04
 rspec --format doc --color --tty spec/baseimage_spec.rb
 
 vagrant-friendly docker baseimages
-  ubuntu-22.04
+  tknerr/baseimage-ubuntu:22.04 (for amd64)
+    is present as a docker image for amd64
     is referenced in a `Vagrantfile` as a docker image
     is not created when I run `vagrant status`
     comes up when I run `vagrant up --no-provision`
@@ -134,11 +165,12 @@ vagrant-friendly docker baseimages
     accepts remote ssh commands via `vagrant ssh -c`
     can be provisioned with a shell script via `vagrant provision`
     is DISTRIB_ID=Ubuntu / DISTRIB_RELEASE=22.04 in lsb-release file
+    is running under amd64 architecture
     can be stopped via `vagrant halt`
     can be destroyed via `vagrant destroy`
 
-Finished in 46.74 seconds (files took 0.31354 seconds to load)
-9 examples, 0 failuress
+Finished in 56.74 seconds (files took 0.31354 seconds to load)
+11 examples, 0 failuress
 ```
 
 In order to build the Vagrant Basebox "wrappers" around it:
@@ -151,15 +183,16 @@ Run integration tests for the Vagrant Basebox:
 $ bundle exec rake test:vagrant:baseboxes PLATFORM=ubuntu-22.04
 rspec --format doc --color --tty spec/basebox_spec.rb
 
-base boxes for the docker baseimages
-  tknerr/baseimage-ubuntu-22.04
+vagrant base boxes for the docker baseimages
+  tknerr/baseimage-ubuntu-22.04 (running on an amd64 host)
     is referenced in a `Vagrantfile` as a basebox
     can be imported via `vagrant box add`
     comes up via `vagrant up --provider docker`
+    creates a docker container for amd64 architecture
     can be destroyed via `vagrant destroy`
 
 Finished in 30.08 seconds (files took 0.61239 seconds to load)
-4 examples, 0 failures
+5 examples, 0 failures
 ```
 
 ### Publishing

--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,9 @@ desc "test the vagrant baseboxes"
 task "test:vagrant:baseboxes" do
   selected_platforms.each_pair do |os, versions|
     versions.each do |version|
-      run_rspec("basebox_spec", os, version)
+      TARGET_ARCHITECTURES.each do |arch|
+        run_rspec("basebox_spec", os, version, arch)
+      end
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,9 @@ desc "test the docker base images"
 task "test:docker:base_images" do
   selected_platforms.each_pair do |os, versions|
     versions.each do |version|
-      run_rspec("baseimage_spec", os, version)
+      TARGET_ARCHITECTURES.each do |arch|
+        run_rspec("baseimage_spec", os, version, arch)
+      end
     end
   end
 end
@@ -134,12 +136,13 @@ def build_vagrant_basebox(os, version)
   end
 end
 
-def run_rspec(spec_name, os, version)
+def run_rspec(spec_name, os, version, arch)
   ENV['OS_UNDER_TEST'] = os.to_s
   ENV['VERSION_UNDER_TEST'] = version.to_s
+  ENV['ARCH_UNDER_TEST'] = arch.to_s
   sh "rspec --format doc --color --tty \
-            --format RspecJunitFormatter --out out/test-results/junit/#{spec_name}-#{os}-#{version}-junit-report.xml \
-            --format html --out out/test-results/#{spec_name}-#{os}-#{version}-test-report.html \
+            --format RspecJunitFormatter --out out/test-results/junit/#{spec_name}-#{os}-#{version}-#{arch}-junit-report.xml \
+            --format html --out out/test-results/#{spec_name}-#{os}-#{version}-#{arch}-test-report.html \
             spec/#{spec_name}.rb"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -72,6 +72,11 @@ task "publish:vagrant:baseboxes" do
   end
 end
 
+desc "clean output directories and destroy builders"
+task "build:cleanup" do
+  sh "git clean -ffdx"
+  destroy_multiarch_docker_builder()
+end
 
 def build_docker_image(os, version)
   create_multiarch_docker_builder()
@@ -86,6 +91,9 @@ end
 def use_multiarch_docker_builder()
   sh "docker buildx use --builder=baseimage-builder"
   sh "docker buildx inspect"
+end
+def destroy_multiarch_docker_builder()
+  sh "docker buildx rm --builder=baseimage-builder || true"
 end
 
 def publish_docker_image(os, version)

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,7 @@ task "test:docker:base_images" do
   selected_platforms.each_pair do |os, versions|
     versions.each do |version|
       TARGET_ARCHITECTURES.each do |arch|
+        import_multiarch_docker_image(os, version, arch)
         run_rspec("baseimage_spec", os, version, arch)
       end
     end
@@ -61,6 +62,7 @@ task "test:vagrant:baseboxes" do
   selected_platforms.each_pair do |os, versions|
     versions.each do |version|
       TARGET_ARCHITECTURES.each do |arch|
+        import_multiarch_docker_image(os, version, arch)
         run_rspec("basebox_spec", os, version, arch)
       end
     end
@@ -98,6 +100,11 @@ def use_multiarch_docker_builder()
 end
 def destroy_multiarch_docker_builder()
   sh "docker buildx rm --builder=baseimage-builder || true"
+end
+def import_multiarch_docker_image(os, version, arch)
+  use_multiarch_docker_builder()
+  sh "docker rmi #{docker_image_name(os, version)} -f"
+  sh "docker buildx build --load --platform=#{docker_platform([arch])} -t #{docker_image_name(os, version)} #{dir(os, version)}"
 end
 
 def publish_docker_image(os, version)

--- a/Rakefile
+++ b/Rakefile
@@ -89,11 +89,11 @@ end
 def publish_vagrant_basebox(os, version)
   desc = "A Vagrant-friendly docker baseimage for #{os.capitalize} #{version}. See https://github.com/tknerr/vagrant-docker-baseimages"
   sh "vagrant cloud publish --release --no-private --short-description='#{desc}' --version-description='#{desc}' \
-        tknerr/baseimage-#{os}-#{version} 1.0.0 docker #{dir(os, version)}/baseimage-#{os}-#{version}.box"
+        #{vagrant_box_name(os, version)} 1.0.0 docker #{vagrant_box_path(os, version)}"
 end
 
 def build_vagrant_basebox(os, version)
-  box = File.open("#{dir(os, version)}/baseimage-#{os}-#{version}.box","wb")
+  box = File.open("#{vagrant_box_path(os, version)}", 'wb')
   Gem::Package::TarWriter.new(box) do |tar|
     tar.add_file("metadata.json", 0644) do |f|
       f.write <<~METADATA
@@ -129,4 +129,10 @@ def dir(os, version)
 end
 def docker_image_name(os, version)
   "tknerr/baseimage-#{os}:#{version}"
+end
+def vagrant_box_name(os, version)
+  "tknerr/baseimage-#{os}-#{version}"
+end
+def vagrant_box_path(os, version)
+  "#{dir(os, version)}/baseimage-#{os}-#{version}.box"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -108,10 +108,11 @@ def import_multiarch_docker_image(os, version, arch)
 end
 
 def publish_docker_image(os, version)
+  use_multiarch_docker_builder()
   sh <<~SCRIPT
     set -e
     docker login
-    docker push #{docker_image_name(os, version)}
+    docker buildx build --push --platform=#{docker_platform(TARGET_ARCHITECTURES)} -t #{docker_image_name(os, version)} #{dir(os, version)}
     docker logout
   SCRIPT
 end

--- a/Rakefile
+++ b/Rakefile
@@ -73,16 +73,15 @@ end
 
 
 def build_docker_image(os, version)
-  image = "tknerr/baseimage-#{os}:#{version}"
-  sh "docker rmi #{image} -f"
-  sh "docker build --no-cache -t #{image} #{dir(os, version)}"
+  sh "docker rmi #{docker_image_name(os, version)} -f"
+  sh "docker build --no-cache -t #{docker_image_name(os, version)} #{dir(os, version)}"
 end
 
 def publish_docker_image(os, version)
   sh <<~SCRIPT
     set -e
     docker login
-    docker push tknerr/baseimage-#{os}:#{version}
+    docker push #{docker_image_name(os, version)}
     docker logout
   SCRIPT
 end
@@ -107,7 +106,7 @@ def build_vagrant_basebox(os, version)
       f.write <<~VAGRANTFILE
         Vagrant.configure(2) do |config|
           config.vm.provider "docker" do |d|
-            d.image = "tknerr/baseimage-#{os}:#{version}"
+            d.image = "#{docker_image_name(os, version)}"
             d.has_ssh = true
           end
         end
@@ -127,4 +126,7 @@ end
 
 def dir(os, version)
   "#{os}-#{version.delete('.')}"
+end
+def docker_image_name(os, version)
+  "tknerr/baseimage-#{os}:#{version}"
 end

--- a/spec/basebox_spec.rb
+++ b/spec/basebox_spec.rb
@@ -10,15 +10,15 @@ describe 'base boxes for the docker baseimages' do
     FileUtils.rm_rf @tempdir
   end
 
-  describe "tknerr/baseimage-#{os}-#{version}" do
+  describe "#{vagrant_box_name(os, version)}" do
     it 'is referenced in a `Vagrantfile` as a basebox' do
       write_config(@tempdir, vagrantfile_referencing_local_basebox(os, version))
       expect(File.read("#{@tempdir}/Vagrantfile")).to include <<~SNIPPET
-        config.vm.box = "tknerr/baseimage-#{os}-#{version}"
+        config.vm.box = "#{vagrant_box_name(os, version)}"
       SNIPPET
     end
     it 'can be imported via `vagrant box add`' do
-      basebox_name = "tknerr/baseimage-#{os}-#{version}"
+      basebox_name = "#{vagrant_box_name(os, version)}"
       basebox_file = "#{os}-#{version.delete('.')}/baseimage-#{os}-#{version}.box"
       result = run_command("vagrant box add --name #{basebox_name} --provider docker --force #{basebox_file}")
       expect(result.stdout).to include "==> box: Box file was not detected as metadata. Adding it directly..."

--- a/spec/basebox_spec.rb
+++ b/spec/basebox_spec.rb
@@ -1,16 +1,17 @@
 require 'spec_helper'
 
-describe 'base boxes for the docker baseimages' do
+describe 'vagrant base boxes for the docker baseimages' do
 
   before(:all) do
     @tempdir = Dir.mktmpdir
+    ENV['DOCKER_DEFAULT_PLATFORM'] = "linux/#{arch}"
   end
 
   after(:all) do
     FileUtils.rm_rf @tempdir
   end
 
-  describe "#{vagrant_box_name(os, version)}" do
+  describe "#{vagrant_box_name(os, version)} (running on an #{arch} host)" do
     it 'is referenced in a `Vagrantfile` as a basebox' do
       write_config(@tempdir, vagrantfile_referencing_local_basebox(os, version))
       expect(File.read("#{@tempdir}/Vagrantfile")).to include <<~SNIPPET
@@ -28,6 +29,12 @@ describe 'base boxes for the docker baseimages' do
     it 'comes up via `vagrant up --provider docker`' do
       result = run_command("vagrant up --provider docker", :cwd => @tempdir)
       expect(result.stdout).to include "==> default: Machine booted and ready!"
+      expect(result.stderr).to match ""
+      expect(result.status.exitstatus).to eq 0
+    end
+    it "creates a docker container for #{arch} architecture" do
+      result = run_command("vagrant ssh -c 'dpkg --print-architecture'", :cwd => @tempdir)
+      expect(result.stdout).to match arch
       expect(result.stderr).to match ""
       expect(result.status.exitstatus).to eq 0
     end

--- a/spec/baseimage_spec.rb
+++ b/spec/baseimage_spec.rb
@@ -11,11 +11,11 @@ describe 'vagrant-friendly docker baseimages' do
     FileUtils.rm_rf @tempdir
   end
 
-  describe "#{os}-#{version}" do
+  describe "#{docker_image_name(os, version)}" do
     it 'is referenced in a `Vagrantfile` as a docker image' do
       write_config(@tempdir, vagrantfile_referencing_docker_baseimage(os, version))
       expect(File.read("#{@tempdir}/Vagrantfile")).to include <<~SNIPPET
-        d.image = "tknerr/baseimage-#{os}:#{version}"
+        d.image = "#{docker_image_name(os, version)}"
       SNIPPET
     end
     it 'is not created when I run `vagrant status`' do
@@ -26,7 +26,7 @@ describe 'vagrant-friendly docker baseimages' do
     end
     it 'comes up when I run `vagrant up --no-provision`' do
       result = run_command("vagrant up --no-provision", :cwd => @tempdir)
-      expect(result.stdout).to include "Image: tknerr/baseimage-#{os}:#{version}"
+      expect(result.stdout).to include "Image: #{docker_image_name(os, version)}"
       expect(result.stdout).to include "==> default: Machine booted and ready!"
       expect(result.stderr).to match ""
       expect(result.status.exitstatus).to eq 0

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -9,16 +9,22 @@ module Helpers
   def os
     ENV.fetch('OS_UNDER_TEST')
   end
-
   def version
     ENV.fetch('VERSION_UNDER_TEST')
+  end
+
+  def docker_image_name(os, version)
+    "tknerr/baseimage-#{os}:#{version}"
+  end
+  def vagrant_box_name(os, version)
+    "tknerr/baseimage-#{os}-#{version}"
   end
 
   def vagrantfile_referencing_docker_baseimage(os, version)
     <<~VAGRANTFILE
       Vagrant.configure(2) do |config|
         config.vm.provider "docker" do |d|
-          d.image = "tknerr/baseimage-#{os}:#{version}"
+          d.image = "#{docker_image_name(os, version)}"
           d.has_ssh = true
         end
 
@@ -31,7 +37,7 @@ module Helpers
   def vagrantfile_referencing_local_basebox(os, version)
     <<~VAGRANTFILE
       Vagrant.configure(2) do |config|
-        config.vm.box = "tknerr/baseimage-#{os}-#{version}"
+        config.vm.box = "#{vagrant_box_name(os, version)}"
         config.vm.box_version = "0"
       end
     VAGRANTFILE

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -12,6 +12,9 @@ module Helpers
   def version
     ENV.fetch('VERSION_UNDER_TEST')
   end
+  def arch
+    ENV.fetch('ARCH_UNDER_TEST')
+  end
 
   def docker_image_name(os, version)
     "tknerr/baseimage-#{os}:#{version}"


### PR DESCRIPTION
Adds multi-arch support for the vagrant docker baseimages:
* use docker buildx to create the baseimages for both amd64 and arm64 architectures
* extend tests to test both the amd64 and arm64 containers
* publish docker images as a multi-arch image with a single manifest
* publish vagrant baseboxes as architecture independent boxes (to let the docker decide which arch to use)

See also:
* https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
* https://www.docker.com/blog/multi-platform-docker-builds/
* https://docs.docker.com/build/building/multi-platform/
* https://docs.docker.com/build/architecture/
* https://namiops.medium.com/build-a-multi-arch-docker-image-with-circleci-for-amd64-arm64-risc64-3ad0537a1f28